### PR TITLE
Add link to diffusers library

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -5,6 +5,54 @@ This repo is the official PyTorch implementation for the paper [Pseudo Numerical
 
 by Luping Liu, Yi Ren, Zhijie Lin, Zhou Zhao (Zhejiang University).
 
+## **Integration with 🤗 Diffusers library**
+
+PNDM is now also available in 🧨 Diffusers and accesible via the [PNDMPipeline](https://huggingface.co/docs/diffusers/api/pipelines/pndm).
+Diffusers allows you to test PNDM in PyTorch in just a couple lines of code.
+
+You can install diffusers as follows:
+
+```
+pip install diffusers torch accelerate
+```
+
+And then try out the sampler/scheduler with just a couple lines of code:
+
+```python
+from diffusers import PNDMPipeline
+
+model_id = "google/ddpm-cifar10-32"
+
+# load model and scheduler
+pndm = PNDMPipeline.from_pretrained(model_id)
+
+# run pipeline in inference (sample random noise and denoise)
+image = pndm(num_inference_steps=50).images[0]
+
+# save image
+image.save("pndm_generated_image.png")
+```
+
+The PNDM scheduler can also be used with more powerful diffusion models such as [Stable Diffusion](https://huggingface.co/docs/diffusers/v0.7.0/en/api/pipelines/stable_diffusion#stable-diffusion-pipelines)
+
+You simply need to [accept the license on the Hub](https://huggingface.co/runwayml/stable-diffusion-v1-5), login with `huggingface-cli login` and install transformers:
+
+```
+pip install transformers
+```
+
+Then you can run:
+
+```python
+from diffusers import StableDiffusionPipeline, PNDMScheduler
+
+pndm = PNDMScheduler.from_config("runwayml/stable-diffusion-v1-5", subfolder="scheduler")
+pipeline = StableDiffusionPipeline.from_pretrained("runwayml/stable-diffusion-v1-5", scheduler=pndm)
+
+image = pipeline("An astronaut riding a horse.").images[0]
+image.save("astronaut_riding_a_horse.png")
+```
+
 ## What does this code do?
 This code is not only the official implementation for PNDM, but also a generic framework for DDIM-like models including:
 - [x] [Pseudo Numerical Methods for Diffusion Models on Manifolds (PNDM)](https://openreview.net/forum?id=PlKWVd2yBkY)

--- a/readme.md
+++ b/readme.md
@@ -5,7 +5,28 @@ This repo is the official PyTorch implementation for the paper [Pseudo Numerical
 
 by Luping Liu, Yi Ren, Zhijie Lin, Zhou Zhao (Zhejiang University).
 
-## **Integration with 🤗 Diffusers library**
+
+## What does this code do?
+This code is not only the official implementation for PNDM, but also a generic framework for DDIM-like models including:
+- [x] [Pseudo Numerical Methods for Diffusion Models on Manifolds (PNDM)](https://openreview.net/forum?id=PlKWVd2yBkY)
+- [x] [Denoising Diffusion Implicit Models (DDIM)](https://arxiv.org/abs/2010.02502)
+- [x] [Score-Based Generative Modeling through Stochastic Differential Equations (PF)](https://arxiv.org/abs/2011.13456)
+- [x] [Improved Denoising Diffusion Probabilistic Models (iDDPM)](https://arxiv.org/abs/2102.09672)
+
+### Structure
+This code contains three main objects including method, schedule and model. The following table shows the options 
+supported by this code and the role of each object.
+
+| Object   | Option                        | Role                                          |
+|----------|-------------------------------|-----------------------------------------------|
+| method   | DDIM, S-PNDM, F-PNDM, FON, PF | the numerical method used to generate samples |
+| schedule | linear, quad, cosine          | the schedule of adding noise to images        |
+| model    | DDIM, iDDPM, PF, PF_deep      | the neural network used to fit noise          |
+
+All of them can be combined at will, so this code provide at least 5x3x4=60 choices to generate samples.
+
+
+## Integration with 🤗 Diffusers library
 
 PNDM is now also available in 🧨 Diffusers and accesible via the [PNDMPipeline](https://huggingface.co/docs/diffusers/api/pipelines/pndm).
 Diffusers allows you to test PNDM in PyTorch in just a couple lines of code.
@@ -53,25 +74,6 @@ image = pipeline("An astronaut riding a horse.").images[0]
 image.save("astronaut_riding_a_horse.png")
 ```
 
-## What does this code do?
-This code is not only the official implementation for PNDM, but also a generic framework for DDIM-like models including:
-- [x] [Pseudo Numerical Methods for Diffusion Models on Manifolds (PNDM)](https://openreview.net/forum?id=PlKWVd2yBkY)
-- [x] [Denoising Diffusion Implicit Models (DDIM)](https://arxiv.org/abs/2010.02502)
-- [x] [Score-Based Generative Modeling through Stochastic Differential Equations (PF)](https://arxiv.org/abs/2011.13456)
-- [x] [Improved Denoising Diffusion Probabilistic Models (iDDPM)](https://arxiv.org/abs/2102.09672)
-
-### Structure
-This code contains three main objects including method, schedule and model. The following table shows the options 
-supported by this code and the role of each object.
-
-| Object   | Option                        | Role                                          |
-|----------|-------------------------------|-----------------------------------------------|
-| method   | DDIM, S-PNDM, F-PNDM, FON, PF | the numerical method used to generate samples |
-| schedule | linear, quad, cosine          | the schedule of adding noise to images        |
-| model    | DDIM, iDDPM, PF, PF_deep      | the neural network used to fit noise          |
-
-All of them can be combined at will, so this code provide at least 5x3x4=60 choices to generate samples.
-
 
 ## How to run the code
 
@@ -118,6 +120,6 @@ If you find the code useful for your research, please consider citing:
 ```
 This work is built upon some previous papers which might also interest you:
 - Jonathan Ho, Ajay Jain, and Pieter Abbeel. Denoising diffusion probabilistic models. Advances in Neural Information Processing Systems 33 (2020): 6840-6851.
-- Jiaming Song, Chenlin Meng, and Stefano Ermon. Denoising Diffusion Implicit Models. International Conference on Learning Representations. 2020.
-- Yang Song, Jascha Sohl-Dickstein, Diederik P. Kingma, Abhishek Kumar, Stefano Ermon, and Ben Poole. Score-Based Generative Modeling through Stochastic Differential Equations. International Conference on Learning Representations. 2020.
+- Jiaming Song, Chenlin Meng, and Stefano Ermon. Denoising Diffusion Implicit Models. International Conference on Learning Representations. 2021.
+- Yang Song, Jascha Sohl-Dickstein, Diederik P. Kingma, Abhishek Kumar, Stefano Ermon, and Ben Poole. Score-Based Generative Modeling through Stochastic Differential Equations. International Conference on Learning Representations. 2021.
 


### PR DESCRIPTION
Hey :wave: from the diffusers team,

Just wanted to ask if you are interested in adding a link to the diffusers library to your README. We're actively maintaining the PNDM pipeline and also enabled use cases to use PNDM with stable diffusion which might be interesting for readers of this repo.

When integrating the PNDM we made sure to have 1-to-1 the same functionality - do you think such an addition could be useful for the readers of your repo? :-) 

Thanks a mille for open-sourcing your method - it has already powered millions of image generations for stable diffusion ;-) 